### PR TITLE
Just spit stdout/err to the console

### DIFF
--- a/lib/gaprice_SPAdes/gaprice_SPAdesImpl.py
+++ b/lib/gaprice_SPAdes/gaprice_SPAdesImpl.py
@@ -160,33 +160,34 @@ Does not currently support assembling metagenomics reads.
         with open(stdout_file, 'w') as spdout, open(stderr_file, 'w') as spderr:
             p = subprocess.Popen(cmd,
                     cwd = self.scratch,
-                    stdout = spdout, 
-                    stderr = spderr, shell = False)
+#                     stdout = spdout, 
+#                     stderr = spderr,
+                    shell = False)
             retcode = p.wait()
         
-        self.log('Standard out:')
-        if self.REPRESS_SPADES_OUTPUT:
-            print('SPAdes output repressed but saved locally.')
-        else:
-            with open(stdout_file) as spdout:
-                for line in spdout:
-                    self.log(line)
-        
-        self.log('Standard error:')
-        with open(stderr_file) as spderr:
-            for line in spderr:
-                self.log(line)
+#         self.log('Standard out:')
+#         if self.REPRESS_SPADES_OUTPUT:
+#             print('SPAdes output repressed but saved locally.')
+#         else:
+#             with open(stdout_file) as spdout:
+#                 for line in spdout:
+#                     self.log(line)
+#         
+#         self.log('Standard error:')
+#         with open(stderr_file) as spderr:
+#             for line in spderr:
+#                 self.log(line)
         
         self.log('Return code: ' + str(retcode))
         if p.returncode != 0:
-            errsize = os.stat(stderr_file).st_size
-            if errsize > 50000:
-                errmsg = 'Standard error too large to return'
-            else:
-                with open(stderr_file) as spderr:
-                    errmsg = 'Standard error:\n' + spderr.read()
+#             errsize = os.stat(stderr_file).st_size
+#             if errsize > 50000:
+#                 errmsg = 'Standard error too large to return'
+#             else:
+#                 with open(stderr_file) as spderr:
+#                     errmsg = 'Standard error:\n' + spderr.read()
             raise ValueError('Error running SPAdes, return code: ' + 
-                             str(retcode) + '\n' + errmsg)
+                             str(retcode) + '\n') # + errmsg)
         
         return outdir
 

--- a/ui/narrative/methods/run_SPAdes/display.yaml
+++ b/ui/narrative/methods/run_SPAdes/display.yaml
@@ -44,4 +44,13 @@ parameters :
             True if the reads are from amplified DNA from a single cell via
             MDA.
 description : |
-    <p>Runs the SPAdes assembler on Illumina FASTQ reads libraries.</p>
+    <p>
+    Runs the <a href="http://bioinf.spbau.ru/spades" target="_blank">SPAdes assembler</a>
+    on Illumina FASTQ reads libraries.</br>
+    </p>
+    
+publications :
+    -
+        display-text: |
+            S. Nurk, A. Bankevich, D. Antipov, A. A. Gurevich, A. Korobeynikov, A. Lapidus, A. D. Prjibelsky, A. Pyshkin, A. Sirotkin, Y. Sirotkin, R. Stepanauskas, J. S. McLean, R. Lasken, S. R. Clingenpeel, T. Woyke, G. Tesler, M. A. Alekseyev, and P. A. Pevzner. Assembling Single-Cell Genomes and Mini-Metagenomes From Chimeric MDA Products. Journal of Computational Biology 20(10) (2013), 714-737. doi:10.1089/cmb.2013.0084
+        link: http://bioinf.spbau.ru/spades


### PR DESCRIPTION
SPAdes keeps a log of its output in any case, and doesn't seem to ever
write to stderr.